### PR TITLE
Invert ccache and checkout actions

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -29,13 +29,13 @@ jobs:
         shell: bash
         run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build ccache
 
-      - name: Setup Ccache
-        uses: hendrikmuhs/ccache-action@main
-
       - uses: actions/checkout@v3
         with:
           repository: duckdb/duckdb
           fetch-depth: 0
+
+      - name: Setup Ccache
+        uses: hendrikmuhs/ccache-action@main
 
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This is trying to fix the fact that ccache is not actually used in rebuilding duckdb.
According to https://github.com/hendrikmuhs/ccache-action#readme ccache should follow checkout.

Either is that, or there needs to be named artifacts, unsure. Also we might want to consider avoiding building duckdb N times, and doing a single build step that then spawns a matrix of sub-jobs.

---

Original curiosity was about how the workflow works at all, in particular if we can repurpose the "testcases as part of issues" to be used for some duckdb issues reproducible at the SQL level.

