### PR TITLE
Separate checks

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -2,14 +2,10 @@ name: CIFuzz
 on:
   workflow_dispatch:
 jobs:
-  fuzzer:
-    name: Fuzzer
+  build-duckdb:
+    name: Build DuckDB
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    strategy:
-      matrix:
-        fuzzer: [duckfuzz, sqlsmith, duckfuzz_functions]
-        data: [alltypes, tpch, emptyalltypes]
     env:
       BUILD_SQLSMITH: 1
       BUILD_ICU: 1
@@ -20,7 +16,6 @@ jobs:
       BUILD_JEMALLOC: 1
       CRASH_ON_ASSERT: 1
       GEN: ninja
-      FUZZEROFDUCKSKEY: ${{ secrets.FUZZEROFDUCKSKEY }}
 
     steps:
       - name: Dependencies
@@ -35,16 +30,40 @@ jobs:
       - name: Setup Ccache
         uses: hendrikmuhs/ccache-action@main
 
-      - uses: actions/checkout@v3
-        with:
-          path: fuzzer
-
       - name: Build
         shell: bash
         run: |
             make debug
 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: duckdb
+          path: build/debug/duckdb
+
+  fuzzer:
+    name: Fuzzer
+    needs:
+    - build-duckdb
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      matrix:
+        fuzzer: [duckfuzz, sqlsmith, duckfuzz_functions]
+        data: [alltypes, tpch, emptyalltypes]
+    env:
+      FUZZEROFDUCKSKEY: ${{ secrets.FUZZEROFDUCKSKEY }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: fuzzer
+
+      - name: Download a single artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: duckdb
+
       - name: Fuzz
         shell: bash
         run: |
-            python3 fuzzer/run_fuzzer.py  --${{ matrix.fuzzer }} --${{ matrix.data }} --shell=build/debug/duckdb
+            python3 fuzzer/run_fuzzer.py  --${{ matrix.fuzzer }} --${{ matrix.data }} --shell=duckdb

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -67,7 +67,8 @@ jobs:
       - name: Fuzz
         shell: bash
         run: |
-            python3 fuzzer/run_fuzzer.py --no_checks --${{ matrix.fuzzer }} --${{ matrix.data }} --shell=duckdb
+            chmod +x duckdb
+            python3 fuzzer/run_fuzzer.py --no_checks --${{ matrix.fuzzer }} --${{ matrix.data }} --shell=./duckdb
 
   check-issues:
     name: Check existing issues
@@ -90,4 +91,5 @@ jobs:
       - name: Fuzz
         shell: bash
         run: |
-            python3 fuzzer/run_fuzzer.py --shell=duckdb
+            chmod +x duckdb
+            python3 fuzzer/run_fuzzer.py --duckfuzz --alltypes --shell=./duckdb

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -47,6 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     strategy:
+      fail-fast: false
       matrix:
         fuzzer: [duckfuzz, sqlsmith, duckfuzz_functions]
         data: [alltypes, tpch, emptyalltypes]
@@ -66,4 +67,27 @@ jobs:
       - name: Fuzz
         shell: bash
         run: |
-            python3 fuzzer/run_fuzzer.py  --${{ matrix.fuzzer }} --${{ matrix.data }} --shell=duckdb
+            python3 fuzzer/run_fuzzer.py --no_checks --${{ matrix.fuzzer }} --${{ matrix.data }} --shell=duckdb
+
+  check-issues:
+    name: Check existing issues
+    needs:
+    - build-duckdb
+    runs-on: ubuntu-latest
+    env:
+      FUZZEROFDUCKSKEY: ${{ secrets.FUZZEROFDUCKSKEY }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: fuzzer
+
+      - name: Download a single artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: duckdb
+
+      - name: Fuzz
+        shell: bash
+        run: |
+            python3 fuzzer/run_fuzzer.py --shell=duckdb

--- a/fuzzer_helper.py
+++ b/fuzzer_helper.py
@@ -120,6 +120,7 @@ def test_reproducibility(shell, issue, current_errors, perform_check):
     sql = extract[0] + ';'
     error = extract[1]
     if perform_check is True:
+        print(f"Checking issue {issue['number']}...")
         (stdout, stderr, returncode) = run_shell_command_batch(shell, sql)
         if returncode == 0:
             return False

--- a/fuzzer_helper.py
+++ b/fuzzer_helper.py
@@ -107,7 +107,11 @@ def extract_issue(body, nr):
 def run_shell_command_batch(shell, cmd):
     command = [shell, '--batch', '-init', '/dev/null']
 
-    res = subprocess.run(command, input=bytearray(cmd, 'utf8'), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    try:
+        res = subprocess.run(command, input=bytearray(cmd, 'utf8'), stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=60)
+    except subprocess.TimeoutExpired:
+        print(f"TIMEOUT... {cmd}")
+        return ("","",0)
     stdout = res.stdout.decode('utf8').strip()
     stderr = res.stderr.decode('utf8').strip()
     return (stdout, stderr, res.returncode)
@@ -138,7 +142,7 @@ def extract_github_issues(shell, perform_check):
         if not test_reproducibility(shell, issue, current_errors, perform_check):
             # the issue appears to be fixed - close the issue
             print(f"Failed to reproduce issue {issue['number']}, closing...")
-            close_github_issue(int(issue['number']))
+            # close_github_issue(int(issue['number']))
     return current_errors
 
 def file_issue(cmd, error_msg, fuzzer, seed, hash):

--- a/fuzzer_helper.py
+++ b/fuzzer_helper.py
@@ -146,7 +146,7 @@ def extract_github_issues(shell, perform_check):
             if not test_reproducibility(shell, issue, current_errors, perform_check):
                 # the issue appears to be fixed - close the issue
                 print(f"Failed to reproduce issue {issue['number']}, closing...")
-                # close_github_issue(int(issue['number']))
+                close_github_issue(int(issue['number']))
     return current_errors
 
 def file_issue(cmd, error_msg, fuzzer, seed, hash):

--- a/fuzzer_helper.py
+++ b/fuzzer_helper.py
@@ -71,9 +71,9 @@ def make_github_issue(title, body):
         print('Response:', r.content.decode('utf8'))
         raise Exception("Failed to create issue")
 
-def get_github_issues():
+def get_github_issues(page):
     session = create_session()
-    url = issue_url()
+    url = issue_url()+'?per_page=100&page='+str(page)
     r = session.get(url)
     if r.status_code != 200:
         print('Failed to get list of issues')
@@ -136,13 +136,14 @@ def test_reproducibility(shell, issue, current_errors, perform_check):
 
 def extract_github_issues(shell, perform_check):
     current_errors = dict()
-    issues = get_github_issues()
-    for issue in issues:
-        # check if the github issue is still reproducible
-        if not test_reproducibility(shell, issue, current_errors, perform_check):
-            # the issue appears to be fixed - close the issue
-            print(f"Failed to reproduce issue {issue['number']}, closing...")
-            # close_github_issue(int(issue['number']))
+    for p in range(1,10):
+        issues = get_github_issues(p)
+        for issue in issues:
+            # check if the github issue is still reproducible
+            if not test_reproducibility(shell, issue, current_errors, perform_check):
+                # the issue appears to be fixed - close the issue
+                print(f"Failed to reproduce issue {issue['number']}, closing...")
+                # close_github_issue(int(issue['number']))
     return current_errors
 
 def file_issue(cmd, error_msg, fuzzer, seed, hash):

--- a/run_fuzzer.py
+++ b/run_fuzzer.py
@@ -12,6 +12,7 @@ seed = -1
 fuzzer = None
 db = None
 shell = None
+perform_checks = True
 for param in sys.argv:
     if param == '--sqlsmith':
         fuzzer = 'sqlsmith'
@@ -25,6 +26,8 @@ for param in sys.argv:
         db = 'tpch'
     elif param == '--emptyalltypes':
         db = 'emptyalltypes'
+    elif param == '--no_checks':
+        perform_checks = False
     elif param.startswith('--shell='):
         shell = param.replace('--shell=', '')
     elif param.startswith('--seed='):
@@ -87,7 +90,7 @@ def run_shell_command(cmd):
 
 
 # first get a list of all github issues, and check if we can still reproduce them
-current_errors = fuzzer_helper.extract_github_issues(shell)
+current_errors = fuzzer_helper.extract_github_issues(shell, perform_checks)
 
 max_queries = 2000
 last_query_log_file = 'sqlsmith.log'


### PR DESCRIPTION
Rework duckdb-fuzzer-ci so that:
- split workflow between building DuckDB, closing fixed open issue, and searching for new ones
- all issues are iterated on
- timeouts (>60 second on reproduction) are for now kept around

Tested on my fork (mocking closing and opening of issues) and seems to work appropriately, about 40% of open issue will likely be closed on the first run(s), see for example this log (with closing mocked: https://github.com/carlopi/duckdb-fuzzer-ci/actions/runs/5773171438/job/15648929561#step:4:355).

To be consider after this:
- removing duplicates (via duckdb!?)
- handling of timeouts

This fixes #3 and I believe renders fuzzing viable again.