### PR TITLE
Pass duckdb hash from build step to fuzzing steps

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -3,11 +3,14 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "*/107 * * * *"
+
 jobs:
   build-duckdb:
     name: Build DuckDB
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    outputs:
+      duckdb-hash: ${{ steps.find-hash.outputs.hash }}
     env:
       BUILD_SQLSMITH: 1
       BUILD_ICU: 1
@@ -32,6 +35,9 @@ jobs:
       - name: Setup Ccache
         uses: hendrikmuhs/ccache-action@main
 
+      - id: find-hash
+        run: echo "::set-output name=hash::$(git rev-parse HEAD)"
+
       - name: Build
         shell: bash
         run: |
@@ -55,6 +61,7 @@ jobs:
         data: [alltypes, tpch, emptyalltypes]
     env:
       FUZZEROFDUCKSKEY: ${{ secrets.FUZZEROFDUCKSKEY }}
+      DUCKDB_HASH: ${{ needs.build-duckdb.outputs.duckdb-hash }}
 
     steps:
       - uses: actions/checkout@v3
@@ -79,6 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FUZZEROFDUCKSKEY: ${{ secrets.FUZZEROFDUCKSKEY }}
+      DUCKDB_HASH: ${{ needs.build-duckdb.outputs.duckdb-hash }}
 
     steps:
       - uses: actions/checkout@v3

--- a/fuzzer_helper.py
+++ b/fuzzer_helper.py
@@ -41,10 +41,6 @@ middle = '''
 footer = '''
 ```'''
 
-def get_github_hash():
-    proc = subprocess.Popen(['git', 'rev-parse', 'HEAD'], stdout=subprocess.PIPE)
-    return proc.stdout.read().decode('utf8').strip()
-
 # github stuff
 def issue_url():
     return 'https://api.github.com/repos/%s/%s/issues' % (REPO_OWNER, REPO_NAME)

--- a/run_fuzzer.py
+++ b/run_fuzzer.py
@@ -48,7 +48,7 @@ if shell is None:
 if seed < 0:
     seed = random.randint(0, 2**30)
 
-git_hash = fuzzer_helper.get_github_hash()
+git_hash = os.getenv('DUCKDB_HASH')
 
 def create_db_script(db):
     if db == 'alltypes':


### PR DESCRIPTION
Forgot to propagate correctly the hash from build step to fuzzing steps, last 3 opened bugs show:

`Issue found by SQLSmith on git commit hash using seed 455172029.`
instead of more informative:
`Issue found by SQLSmith on git commit hash [somehash] using seed 455172029.`

Fixes seems to make sense to me, but are untested.