### PR TITLE
Add dry option

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -1,0 +1,95 @@
+name: CIFuzz
+on:
+  workflow_dispatch:
+  repository_dispatch:
+  push:
+    branches:
+      - '**'
+      - '!main'
+      - '!feature'
+    tags:
+      - '**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build-duckdb:
+    name: Build DuckDB
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    outputs:
+      duckdb-hash: ${{ steps.find-hash.outputs.hash }}
+    env:
+      BUILD_SQLSMITH: 1
+      BUILD_ICU: 1
+      BUILD_JSON: 1
+      BUILD_TPCH: 1
+      BUILD_TPCDS: 1
+      BUILD_PARQUET: 1
+      BUILD_JEMALLOC: 1
+      CRASH_ON_ASSERT: 1
+      GEN: ninja
+
+    steps:
+      - name: Dependencies
+        shell: bash
+        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build ccache
+
+      - uses: actions/checkout@v3
+        with:
+          repository: duckdb/duckdb
+          fetch-depth: 0
+
+      - name: Setup Ccache
+        uses: hendrikmuhs/ccache-action@main
+
+      - id: find-hash
+        run: echo "::set-output name=hash::$(git rev-parse HEAD)"
+
+      - name: Build
+        shell: bash
+        run: |
+            make debug
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: duckdb
+          path: build/debug/duckdb
+
+
+  fuzzer:
+    name: Fuzzer
+    needs:
+    - build-duckdb
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        fuzzer: [duckfuzz, sqlsmith, duckfuzz_functions]
+        data: [alltypes, tpch, emptyalltypes]
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: fuzzer
+
+      - name: Download a single artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: duckdb
+
+      - name: Fuzz local
+        shell: bash
+        run: |
+            chmod +x duckdb
+            runtime="10 minute"
+            endtime=$(date -ud "$runtime" +%s)
+
+            while [[ $(date -u +%s) -le $endtime ]]
+            do
+                echo "Time Now: `date +%H:%M:%S`"
+                python3 fuzzer/run_fuzzer.py --no_checks ----${{ matrix.fuzzer }} --${{ matrix.data }} --shell=./duckdb --local
+            done

--- a/fuzzer_helper.py
+++ b/fuzzer_helper.py
@@ -144,7 +144,7 @@ def test_reproducibility(shell, issue, current_errors, perform_check):
         else:
             if returncode == 0:
                 return False
-            if not fuzzer_helper.is_internal_error(stderr):
+            if not is_internal_error(stderr):
                 return False
     # issue is still reproducible
     current_errors[error] = issue
@@ -172,15 +172,3 @@ def file_issue(cmd, error_msg, fuzzer, seed, hash):
     print(title, body)
     make_github_issue(title, body)
 
-def is_internal_error(error):
-    if 'differs from original result' in error:
-        return True
-    if 'INTERNAL' in error:
-        return True
-    if 'signed integer overflow' in error:
-        return True
-    if 'Sanitizer' in error or 'sanitizer' in error:
-        return True
-    if 'runtime error' in error:
-        return True
-    return False

--- a/reduce_sql.py
+++ b/reduce_sql.py
@@ -2,7 +2,6 @@ import re
 import subprocess
 import time
 import os
-import fuzzer_helper
 import multiprocessing
 import sqlite3
 

--- a/run_fuzzer.py
+++ b/run_fuzzer.py
@@ -12,7 +12,7 @@ fuzzer = None
 db = None
 shell = None
 perform_checks = True
-run_dry = False
+local_run = False
 for param in sys.argv:
     if param == '--sqlsmith':
         fuzzer = 'sqlsmith'
@@ -32,10 +32,10 @@ for param in sys.argv:
         shell = param.replace('--shell=', '')
     elif param.startswith('--seed='):
         seed = int(param.replace('--seed=', ''))
-    elif param == '--dry':
-        run_dry = True
+    elif param == '--local':
+        local_run = True
 
-if not run_dry:
+if not local_run:
     import fuzzer_helper
 
 if fuzzer is None:
@@ -107,7 +107,7 @@ def run_shell_command(cmd):
     return (stdout, stderr, res.returncode)
 
 
-if not run_dry:
+if not local_run:
     # first get a list of all github issues, and check if we can still reproduce them
     current_errors = fuzzer_helper.extract_github_issues(shell, perform_checks)
 else:
@@ -150,7 +150,7 @@ if returncode == 0:
 
 
 reproduction_method = "Attempting to reproduce ..."
-if not run_dry:
+if not local_run:
     reproduction_method = "Attempting to reproduce and file issue..."
 
 print("==============  FAILURE  ================")
@@ -202,5 +202,5 @@ last_query = reduce_sql.reduce(last_query, load_script, shell, error_msg)
 cmd = load_script + '\n' + last_query + "\n"
 
 
-if not run_dry:
+if not local_run:
     fuzzer_helper.file_issue(cmd, error_msg, fuzzer_name, seed, git_hash)

--- a/run_fuzzer.py
+++ b/run_fuzzer.py
@@ -4,7 +4,6 @@ import sys
 import os
 import subprocess
 import reduce_sql
-import fuzzer_helper
 import random
 
 seed = -1
@@ -13,6 +12,7 @@ fuzzer = None
 db = None
 shell = None
 perform_checks = True
+run_dry = False
 for param in sys.argv:
     if param == '--sqlsmith':
         fuzzer = 'sqlsmith'
@@ -32,6 +32,11 @@ for param in sys.argv:
         shell = param.replace('--shell=', '')
     elif param.startswith('--seed='):
         seed = int(param.replace('--seed=', ''))
+    elif param == '--dry':
+        run_dry = True
+
+if not run_dry:
+    import fuzzer_helper
 
 if fuzzer is None:
     print("Unrecognized fuzzer to run, expected e.g. --sqlsmith or --duckfuzz")
@@ -49,6 +54,19 @@ if seed < 0:
     seed = random.randint(0, 2**30)
 
 git_hash = os.getenv('DUCKDB_HASH')
+
+def is_internal_error(error):
+    if 'differs from original result' in error:
+        return True
+    if 'INTERNAL' in error:
+        return True
+    if 'signed integer overflow' in error:
+        return True
+    if 'Sanitizer' in error or 'sanitizer' in error:
+        return True
+    if 'runtime error' in error:
+        return True
+    return False
 
 def create_db_script(db):
     if db == 'alltypes':
@@ -89,8 +107,11 @@ def run_shell_command(cmd):
     return (stdout, stderr, res.returncode)
 
 
-# first get a list of all github issues, and check if we can still reproduce them
-current_errors = fuzzer_helper.extract_github_issues(shell, perform_checks)
+if not run_dry:
+    # first get a list of all github issues, and check if we can still reproduce them
+    current_errors = fuzzer_helper.extract_github_issues(shell, perform_checks)
+else:
+    current_errors = []
 
 max_queries = 2000
 last_query_log_file = 'sqlsmith.log'
@@ -127,8 +148,13 @@ if returncode == 0:
     print("==============  SUCCESS  ================")
     exit(0)
 
+
+reproduction_method = "Attempting to reproduce ..."
+if not run_dry:
+    reproduction_method = "Attempting to reproduce and file issue..."
+
 print("==============  FAILURE  ================")
-print("Attempting to reproduce and file issue...")
+print(reproduction_method)
 
 # run the last query, and see if the issue persists
 with open(last_query_log_file, 'r') as f:
@@ -146,7 +172,9 @@ print(stdout)
 print("==============  STDERR  =================")
 print(stderr)
 print("==========================================")
-if not fuzzer_helper.is_internal_error(stderr):
+
+
+if not is_internal_error(stderr):
     print("Failed to reproduce the internal error with a single command")
     exit(0)
 
@@ -173,4 +201,6 @@ print("=========================================")
 last_query = reduce_sql.reduce(last_query, load_script, shell, error_msg)
 cmd = load_script + '\n' + last_query + "\n"
 
-fuzzer_helper.file_issue(cmd, error_msg, fuzzer_name, seed, git_hash)
+
+if not run_dry:
+    fuzzer_helper.file_issue(cmd, error_msg, fuzzer_name, seed, git_hash)


### PR DESCRIPTION
Gives the user the ability to run the fuzzer without needing keys to the [duckdb-fuzzer](https://github.com/duckdb/duckdb-fuzzer) repo.

Includes a github action to run the fuzzer as if it was local to make sure the script doesn't break