### PR TITLE
Fuzz with enable_verification

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,8 +1,8 @@
 name: CIFuzz
 on:
   workflow_dispatch:
-  # schedule:
-    # - cron: "*/107 * * * *"
+  schedule:
+    - cron: "*/107 * * * *"
 
 jobs:
   build-duckdb:

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -100,12 +100,8 @@ jobs:
 
             while [[ $(date -u +%s) -le $endtime ]]
             do
-                echo "Time Now: `date +%H:%M:%S`"
-                if [ "${{ matrix.enable_verification }}" == "true" ]; then
-                  python3 scripts/run_fuzzer.py --no_checks --${{ matrix.fuzzer }} --${{ matrix.data }} --enable_verification --max_queries=1000 --shell=../duckdb
-                else
-                  python3 scripts/run_fuzzer.py --no_checks --${{ matrix.fuzzer }} --${{ matrix.data }} --max_queries=1000 --shell=../duckdb
-                fi
+              echo "Time Now: `date +%H:%M:%S`"
+              python3 scripts/run_fuzzer.py --no_checks --${{ matrix.fuzzer }} --${{ matrix.data }} --enable_verification=${{ matrix.enable_verification }} --max_queries=1000 --shell=../duckdb
             done
 
 

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,8 +1,8 @@
 name: CIFuzz
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "*/107 * * * *"
+  # schedule:
+    # - cron: "*/107 * * * *"
 
 jobs:
   build-duckdb:

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -69,7 +69,9 @@ jobs:
         enable_verification: [true, false]
         exclude:
           - enable_verification: true
-            fuzzer: [sqlsmith, duckfuzz_functions]
+            fuzzer: sqlsmith
+          - enable_verification: true
+            fuzzer: duckfuzz_functions
     env:
       FUZZEROFDUCKSKEY: ${{ secrets.FUZZEROFDUCKSKEY }}
       DUCKDB_HASH: ${{ needs.build-duckdb.outputs.duckdb-hash }}
@@ -99,7 +101,7 @@ jobs:
             while [[ $(date -u +%s) -le $endtime ]]
             do
                 echo "Time Now: `date +%H:%M:%S`"
-                if [[ ${{ matrix.enable_verification == 'true' }} ]]; then
+                if [ "${{ matrix.enable_verification }}" == "true" ]; then
                   python3 scripts/run_fuzzer.py --no_checks --${{ matrix.fuzzer }} --${{ matrix.data }} --enable_verification --max_queries=1000 --shell=../duckdb
                 else
                   python3 scripts/run_fuzzer.py --no_checks --${{ matrix.fuzzer }} --${{ matrix.data }} --max_queries=1000 --shell=../duckdb

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,8 +1,8 @@
 name: CIFuzz
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "*/107 * * * *"
+  # schedule:
+    # - cron: "*/107 * * * *"
 
 jobs:
   build-duckdb:
@@ -35,7 +35,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@main
 
       - id: find-hash
-        run: echo "::set-output name=hash::$(git rev-parse HEAD)"
+        run: echo "hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - name: create build sqlsmith extension file
         shell: bash
@@ -66,6 +66,10 @@ jobs:
       matrix:
         fuzzer: [duckfuzz, sqlsmith, duckfuzz_functions]
         data: [alltypes, tpch, emptyalltypes]
+        enable_verification: [true, false]
+        exclude:
+          - enable_verification: true
+            fuzzer: [sqlsmith, duckfuzz_functions]
     env:
       FUZZEROFDUCKSKEY: ${{ secrets.FUZZEROFDUCKSKEY }}
       DUCKDB_HASH: ${{ needs.build-duckdb.outputs.duckdb-hash }}
@@ -95,7 +99,11 @@ jobs:
             while [[ $(date -u +%s) -le $endtime ]]
             do
                 echo "Time Now: `date +%H:%M:%S`"
-                python3 scripts/run_fuzzer.py --no_checks --${{ matrix.fuzzer }} --${{ matrix.data }} --max_queries=1000 --shell=../duckdb
+                if [[ ${{ matrix.enable_verification == 'true' }} ]]; then
+                  python3 scripts/run_fuzzer.py --no_checks --${{ matrix.fuzzer }} --${{ matrix.data }} --enable_verification --max_queries=1000 --shell=../duckdb
+                else
+                  python3 scripts/run_fuzzer.py --no_checks --${{ matrix.fuzzer }} --${{ matrix.data }} --max_queries=1000 --shell=../duckdb
+                fi
             done
 
 


### PR DESCRIPTION
This PR modifies the `cifuzz.yml` workflow to use the `enable_verification` flag when running `duckfuzz`.

The changes ensure that `duckfuzz` runs with the --ENABLE_VERIFICATION option when the `enable_verification` flag is set to `true` in the matrix configuration.

You can find the related PR that enables running the fuzzer with `enable_verification` here: [duckdb/duckdb_sqlsmith#20](https://github.com/duckdb/duckdb_sqlsmith/pull/20).