### PR TITLE
try to upload different artifacts

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -26,7 +26,7 @@ jobs:
         shell: bash
         run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build ccache
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: duckdb/duckdb
           fetch-depth: 0
@@ -50,7 +50,7 @@ jobs:
         run: |
           EXTENSION_CONFIGS="sqlsmith.cmake" make debug
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: duckdb
           path: build/debug/duckdb
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: checkout duckdb_sqlsmith
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: duckdb/duckdb_sqlsmith
           path: duckdb_sqlsmith
@@ -80,7 +80,7 @@ jobs:
             scripts
 
       - name: Download a single artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: duckdb
 
@@ -97,7 +97,13 @@ jobs:
                 echo "Time Now: `date +%H:%M:%S`"
                 python3 scripts/run_fuzzer.py --no_checks --${{ matrix.fuzzer }} --${{ matrix.data }} --max_queries=1000 --shell=../duckdb
             done
-
+          
+      - name: Upload fuzz_clogs
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz_clogs_${{ matrix.fuzzer }}_${{ matrix.data }}
+          path: duckdb_sqlsmith/sqlsmith.complete.log
+          compression-level: 9
 
   check-issues:
     name: Check existing issues
@@ -109,7 +115,7 @@ jobs:
       DUCKDB_HASH: ${{ needs.build-duckdb.outputs.duckdb-hash }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: duckdb/duckdb_sqlsmith
           path: duckdb_sqlsmith
@@ -117,7 +123,7 @@ jobs:
             scripts
 
       - name: Download a single artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: duckdb
 

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -98,10 +98,10 @@ jobs:
                 python3 scripts/run_fuzzer.py --no_checks --${{ matrix.fuzzer }} --${{ matrix.data }} --max_queries=1000 --shell=../duckdb
             done
           
-      - name: Upload fuzz_clogs
+      - name: Upload fuzz_complete_logs
         uses: actions/upload-artifact@v4
         with:
-          name: fuzz_clogs_${{ matrix.fuzzer }}_${{ matrix.data }}
+          name: fuzz_complete_logs_${{ matrix.fuzzer }}_${{ matrix.data }}.sql
           path: duckdb_sqlsmith/sqlsmith.complete.log
           compression-level: 9
 


### PR DESCRIPTION
This PR makes `CIFuzz` upload the complete logs as one archive, as it described in https://github.com/duckdblabs/duckdb-fuzzer-ci/issues/31
And I also changed actions versions for `checkout`, `download` and `upload` to mute the warnings of the GH Actions runner.