### PR TITLE
fix the logs uploading

### DIFF
--- a/.github/workflows/cifuzz-basic.yml
+++ b/.github/workflows/cifuzz-basic.yml
@@ -33,5 +33,6 @@ jobs:
       timeout-minutes: 120
       max_queries: 10
       no-git-checks: true
+      enable_verification: false
     secrets:
       DUCKDB_HASH: ${{ needs.build-duckdb.outputs.duckdb-hash }}

--- a/.github/workflows/cifuzz-basic.yml
+++ b/.github/workflows/cifuzz-basic.yml
@@ -13,8 +13,8 @@ jobs:
     name: Build DuckDB
     uses: ./.github/workflows/build_fuzzer.yml
     with:
-      git_url: ${{ github.repository }}
-      git_tag: ${{ github.ref_name }}
+      git_url: duckdb/duckdb_sqlsmith
+      git_tag: main
       timeout-minutes: 120
 
   fuzzer:

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -30,6 +30,7 @@ jobs:
             fuzzer: duckfuzz_functions
     uses: ./.github/workflows/fuzz_duckdb.yml
     with:
+      repo: duckdb/duckdb_sqlsmith
       fuzzer: ${{ matrix.fuzzer }}
       data: ${{ matrix.data }}
       timeout-minutes: 120

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -30,7 +30,6 @@ jobs:
             fuzzer: duckfuzz_functions
     uses: ./.github/workflows/fuzz_duckdb.yml
     with:
-      repo: duckdb/duckdb_sqlsmith
       fuzzer: ${{ matrix.fuzzer }}
       data: ${{ matrix.data }}
       timeout-minutes: 120

--- a/.github/workflows/fuzz_duckdb.yml
+++ b/.github/workflows/fuzz_duckdb.yml
@@ -21,9 +21,11 @@ on:
         type: number
         default: 1000
       enable_verification:
-        required: false
+        required: true
         type: boolean
-        default: false
+      repo: 
+        required: true
+        type: string
     secrets:
       FUZZEROFDUCKSKEY:
         required: false

--- a/.github/workflows/fuzz_duckdb.yml
+++ b/.github/workflows/fuzz_duckdb.yml
@@ -24,9 +24,6 @@ on:
         required: false
         type: boolean
         default: false
-      repo: 
-        required: true
-        type: string
     secrets:
       FUZZEROFDUCKSKEY:
         required: false
@@ -42,7 +39,7 @@ jobs:
       - name: checkout duckdb_sqlsmith
         uses: actions/checkout@v4
         with:
-          repository: ${{ inputs.repo }}
+          repository: duckdb/duckdb_sqlsmith
           path: duckdb_sqlsmith
           sparse-checkout: |
             scripts

--- a/.github/workflows/fuzz_duckdb.yml
+++ b/.github/workflows/fuzz_duckdb.yml
@@ -23,6 +23,9 @@ on:
       enable_verification:
         required: true
         type: boolean
+      repo: 
+        required: true
+        type: string
     secrets:
       FUZZEROFDUCKSKEY:
         required: false
@@ -38,7 +41,7 @@ jobs:
       - name: checkout duckdb_sqlsmith
         uses: actions/checkout@v4
         with:
-          repository: hmeriann/duckdb_sqlsmith
+          repository: ${{ inputs.repo }}
           path: duckdb_sqlsmith
           sparse-checkout: |
             scripts
@@ -75,4 +78,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: fuzz_complete_logs_${{ inputs.fuzzer }}_${{ inputs.data }}_ev_is_${{ inputs.enable_verification }}.sql
-          path: duckdb_sqlsmith/sqlsmith.complete.log
+          path: duckdb_sqlsmith/fuzz_complete_logs_${{ inputs.fuzzer }}_${{ inputs.data }}_ev_is_${{ inputs.enable_verification }}.sql

--- a/.github/workflows/fuzz_duckdb.yml
+++ b/.github/workflows/fuzz_duckdb.yml
@@ -21,8 +21,9 @@ on:
         type: number
         default: 1000
       enable_verification:
-        required: true
+        required: false
         type: boolean
+        default: false
       repo: 
         required: true
         type: string


### PR DESCRIPTION
I've noticed that the Fuzzer complete logs are [not being uploaded](https://github.com/duckdblabs/duckdb-fuzzer-ci/actions/runs/10825057476) after renaming them. 
* Fixed it ~~and also added passing the `git_url` from the caller workflow to the reusable `fuzz_duckdb`~~
* This PR also makes `enable_verification` parameter optional, so `cibasic-fuzz` don't have to provide a value for it - by default it will be `false`. [The problem](https://github.com/hmeriann/duckdb-fuzzer-ci/actions/runs/10829571424) 