### PR TITLE
fix propagation of duckdb hash between jobs

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -42,7 +42,7 @@ jobs:
       repo: ${{ github.repository }}
     secrets:
       FUZZEROFDUCKSKEY: ${{ secrets.FUZZEROFDUCKSKEY }}
-      DUCKDB_HASH: ${{ needs.build-duckdb.outputs.duckdb-hash }}
+      DUCKDB_HASH: ${{ needs.build-duckdb.outputs.hash }}
 
   check-issues:
     name: Check existing issues
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FUZZEROFDUCKSKEY: ${{ secrets.FUZZEROFDUCKSKEY }}
-      DUCKDB_HASH: ${{ needs.build-duckdb.outputs.duckdb-hash }}
+      DUCKDB_HASH: ${{ needs.build-duckdb.outputs.hash }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/fuzz_duckdb.yml
+++ b/.github/workflows/fuzz_duckdb.yml
@@ -2,7 +2,7 @@ name: Fuzz DuckDb
 on:
   workflow_call:
     inputs:
-      fuzzer: 
+      fuzzer:
         required: true
         type: string
       data:
@@ -23,14 +23,14 @@ on:
       enable_verification:
         required: true
         type: boolean
-      repo: 
+      repo:
         required: true
         type: string
     secrets:
       FUZZEROFDUCKSKEY:
         required: false
-      DUCKDB_HASH: 
-        required: false
+      DUCKDB_HASH:
+        required: true
 
 jobs:
   fuzzer:
@@ -61,7 +61,7 @@ jobs:
           runtime="1 minute"
           endtime=$(date -ud "$runtime" +%s)
           cd duckdb_sqlsmith
-      
+
           while [[ $(date -u +%s) -le $endtime ]]
           do
               echo "Time Now: `date +%H:%M:%S`"


### PR DESCRIPTION
The duckdb SHA was missing from issues generated by the fuzzer.
See for example: the first line in: https://github.com/duckdb/duckdb-fuzzer/issues/3990 
This fix adds the duckdb SHA, see for example https://github.com/duckdb/duckdb-fuzzer/issues/4077