### PR TITLE
Add dynamic symbols

### DIFF
--- a/.github/workflows/build_fuzzer.yml
+++ b/.github/workflows/build_fuzzer.yml
@@ -2,7 +2,7 @@ name: Build Fuzzer
 on:
   workflow_call:
     inputs:
-      git_url: 
+      git_url:
         required: true
         type: string
       git_tag:
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build-duckdb:
-    name: Build 
+    name: Build
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout-minutes }}
     outputs:
@@ -31,6 +31,7 @@ jobs:
       BUILD_PARQUET: 1
       BUILD_JEMALLOC: 1
       CRASH_ON_ASSERT: 1
+      EXPORT_DYNAMIC_SYMBOLS: 1
       GEN: ninja
 
     steps:
@@ -45,14 +46,14 @@ jobs:
 
       - name: Setup Ccache
         uses: hendrikmuhs/ccache-action@main
-  
+
       - id: find-hash
         run: echo "hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-  
+
       - name: create build sqlsmith extension file
         shell: bash
         run: |
-          echo "duckdb_extension_load(sqlsmith 
+          echo "duckdb_extension_load(sqlsmith
             GIT_URL https://github.com/${{ inputs.git_url }}
             GIT_TAG ${{ inputs.git_tag }}
           )" > sqlsmith.cmake

--- a/.github/workflows/cifuzz-basic.yml
+++ b/.github/workflows/cifuzz-basic.yml
@@ -39,4 +39,4 @@ jobs:
       enable_verification: false
       repo: ${{ github.repository }}
     secrets:
-      DUCKDB_HASH: ${{ needs.build-duckdb.outputs.duckdb-hash }}
+      DUCKDB_HASH: ${{ needs.build-duckdb.outputs.hash }}


### PR DESCRIPTION
Fix for issue https://github.com/duckdblabs/duckdb-fuzzer-ci/issues/43

Compiler flag `EXPORT_DYNAMIC_SYMBOLS` adds symbol names to stack trace for Linux builds.
Also see: https://github.com/duckdb/duckdb/pull/15587

Example issue created with this flag via manual run with older duckdb build: https://github.com/duckdb/duckdb-fuzzer/issues/4082

Pointer addresses are removed from the stack trace when the issue is logged in `duckdb-sqlsmith`.
Included in PR [https://github.com/duckdb/duckdb-sqlsmith/pull/41](https://github.com/duckdb/duckdb-sqlsmith/pull/41) (commit [a02a94](https://github.com/duckdb/duckdb-sqlsmith/pull/41/commits/a02a940b04a11fe2f53d779010222afed467e420))

