### PR TITLE
Revert "disable cron"

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,8 +1,8 @@
 name: CIFuzz
 on:
   workflow_dispatch:
-  # schedule:
-  #   - cron: "*/107 * * * *"
+  schedule:
+    - cron: "*/107 * * * *"
 
 jobs:
   build-duckdb:


### PR DESCRIPTION
This reverts commit f3069e67ee4a0deef784e1fc377859e6ddf2159f.

Action https://github.com/duckdblabs/duckdb-fuzzer-ci/actions/workflows/cifuzz.yml was temporarily disabled because it kept crashing when reproducing https://github.com/duckdb/duckdb-fuzzer/issues/2702

That issue is closed now, so it should run fine again.
Long term solution will be looked into as part of https://github.com/duckdblabs/duckdb-fuzzer-ci/issues/47