### PR TITLE
fix installing sqlsmith extension

### DIFF
--- a/.github/workflows/build_fuzzer.yml
+++ b/.github/workflows/build_fuzzer.yml
@@ -50,13 +50,18 @@ jobs:
       - id: find-hash
         run: echo "hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Build
+      - name: create build sqlsmith extension file
         shell: bash
         run: |
           echo "duckdb_extension_load(sqlsmith
             GIT_URL https://github.com/${{ inputs.git_url }}
             GIT_TAG ${{ inputs.git_tag }}
           )" > sqlsmith.cmake
+
+      - name: Build
+        shell: bash
+        run: |
+          EXTENSION_CONFIGS="sqlsmith.cmake" make debug
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_fuzzer.yml
+++ b/.github/workflows/build_fuzzer.yml
@@ -50,19 +50,11 @@ jobs:
       - id: find-hash
         run: echo "hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
-      - name: create build sqlsmith extension file
-        shell: bash
-        run: |
-          echo "duckdb_extension_load(sqlsmith
-            GIT_URL https://github.com/${{ inputs.git_url }}
-            GIT_TAG ${{ inputs.git_tag }}
-            APPLY_PATCHES
-          )" > sqlsmith.cmake
-
       - name: Build
         shell: bash
         run: |
-          EXTENSION_CONFIGS="sqlsmith.cmake" make debug
+          CORE_EXTENSIONS="sqlsmith" make debug
+          ./build/debug/duckdb -c "INSTALL sqlsmith FROM 'build/debug/repository';"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_fuzzer.yml
+++ b/.github/workflows/build_fuzzer.yml
@@ -53,8 +53,10 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          CORE_EXTENSIONS="sqlsmith" make debug
-          ./build/debug/duckdb -c "INSTALL sqlsmith FROM 'build/debug/repository';"
+          echo "duckdb_extension_load(sqlsmith
+            GIT_URL https://github.com/${{ inputs.git_url }}
+            GIT_TAG ${{ inputs.git_tag }}
+          )" > sqlsmith.cmake
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
`APPLY_PATCHES` raises an error if there are no patches
Therefore, applied alternative installation method for `sqlsmith` extension