### PR TITLE
Revert "Merge pull request #51 from c-herrewijn/fix-ci"

### DIFF
--- a/.github/workflows/build_fuzzer.yml
+++ b/.github/workflows/build_fuzzer.yml
@@ -56,6 +56,7 @@ jobs:
           echo "duckdb_extension_load(sqlsmith
             GIT_URL https://github.com/${{ inputs.git_url }}
             GIT_TAG ${{ inputs.git_tag }}
+            APPLY_PATCHES
           )" > sqlsmith.cmake
 
       - name: Build


### PR DESCRIPTION
This reverts commit c6a1a3d4a809e9d5b25e0a48202313f506278265, reversing changes made to 32f7ea9bb5780eb9dfe2ff0cc1b06b96d9476738.

@Tmonster do you think it is a good idea to create a function `APPLY_PATCHES_IF_EXIST` ? 

Currently the fuzzer breaks in the course of a release cycle depending on whether or not there are patches for sqlsmith, which is a bit cumbersome. 

